### PR TITLE
fix core dump due to memory corruption

### DIFF
--- a/src/Joy4004482.cpp
+++ b/src/Joy4004482.cpp
@@ -19,18 +19,16 @@
 #include <stdexcept>
 #include "Joy4004482.h"
 //---------------------------------------------------------------------------
-Joy4004482::Joy4004482(IifGPIO *pio, TSettings::SetJoystick* settings)
+Joy4004482::Joy4004482(IifGPIO *pio, TSettings::SetJoystick* settings) :
+	joy{{ nullptr, nullptr, false, 0 }, { nullptr, nullptr, false, 0 }},
+	joyCnt(0),
+	sameDev(false)
 {
 	if (!pio)
 		throw std::runtime_error("Required GPIO not initialized!");
 
 	this->pio = pio;
 	this->settings = settings;
-
-	sameDev = false;
-	joyCnt = 0;
-
-	memset(joy, 0, sizeof(joy) * 2);
 }
 //---------------------------------------------------------------------------
 Joy4004482::~Joy4004482()

--- a/src/Joy4004482.cpp
+++ b/src/Joy4004482.cpp
@@ -16,19 +16,15 @@
 	along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 //---------------------------------------------------------------------------
-#include <stdexcept>
 #include "Joy4004482.h"
 //---------------------------------------------------------------------------
 Joy4004482::Joy4004482(IifGPIO *pio, TSettings::SetJoystick* settings) :
-	joy{{ nullptr, nullptr, false, 0 }, { nullptr, nullptr, false, 0 }},
+	pio(pio),
+	settings(settings),
+	joy{{ NULL, NULL, false, 0 }, { NULL, NULL, false, 0 }},
 	joyCnt(0),
 	sameDev(false)
 {
-	if (!pio)
-		throw std::runtime_error("Required GPIO not initialized!");
-
-	this->pio = pio;
-	this->settings = settings;
 }
 //---------------------------------------------------------------------------
 Joy4004482::~Joy4004482()


### PR DESCRIPTION
I was getting quite often core dumps when starting emulator, e.g:
```
DBG: [Screen] Windowed mode: 1440x1300 -> viewport: 1440x1280
DBG: [Sound] Initialized device to 44100Hz/8bit with 1024B (2048B) buffer
malloc(): unaligned tcache chunk detected
Aborted (core dumped)
```

finding the cause with help of valgrind:
```
...
DBG: [Sound] Initialized device to 44100Hz/8bit with 1024B (2048B) buffer
==47796== Invalid write of size 8
==47796==    at 0x48527F7: memset (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47796==    by 0x14D5AB: Joy4004482::Joy4004482(IifGPIO*, TSettings::SetJoystick*) (Joy4004482.cpp:36)
==47796==    by 0x12C414: TEmulator::SetComputerModel(bool, int, unsigned char*) (Emulator.cpp:1396)
==47796==    by 0x1290E4: TEmulator::ProcessSettings(unsigned char) (Emulator.cpp:372)
==47796==    by 0x11CA2F: main (GPMD85emu.cpp:106)
==47796==  Address 0x125d4310 is 0 bytes after a block of size 144 alloc'd
==47796==    at 0x4849013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==47796==    by 0x12C3F0: TEmulator::SetComputerModel(bool, int, unsigned char*) (Emulator.cpp:1396)
==47796==    by 0x1290E4: TEmulator::ProcessSettings(unsigned char) (Emulator.cpp:372)
==47796==    by 0x11CA2F: main (GPMD85emu.cpp:106)
==47796== 
==47796== Invalid write of size 8
...
```

To fix it, I changed the way the joy[2] was initialized in Joy4004482 constructor.

-jan