### PR TITLE
Refactor popup dialogs

### DIFF
--- a/gui/CommonDialog.cpp
+++ b/gui/CommonDialog.cpp
@@ -31,6 +31,10 @@ void UserInterface::AboutDialog()
 	}
 
 	menuStackLevel++;
+	menuStack[menuStackLevel].type = GUI_TYPE_ABOUT_DIALOG;
+	menuStack[menuStackLevel].data = NULL;
+	menuStack[menuStackLevel].frame = NULL;
+	menuStack[menuStackLevel].hilite = 0;
 
 	sprintf(
 		msgbuffer,
@@ -111,66 +115,9 @@ void UserInterface::AboutDialog()
 		warning("GUI", "Can't load icon resource file");
 
 	UnlockSurface(defaultTexture, defaultSurface);
-	SDL_Delay(GPU_TIMER_INTERVAL);
-
-	i = 1;
-	DWORD nextTick;
-	SDL_Event event;
-
-	while (i) {
-		nextTick = SDL_GetTicks() + CPU_TIMER_INTERVAL;
-
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					switch (event.key.keysym.scancode) {
-						case SDL_SCANCODE_SPACE:
-						case SDL_SCANCODE_ESCAPE:
-						case SDL_SCANCODE_RETURN:
-						case SDL_SCANCODE_KP_ENTER:
-							i = 0;
-							break;
-
-						default:
-							break;
-					}
-					break;
-
-				case SDL_WINDOWEVENT:
-					if (event.window.windowID == gdc.windowID &&
-						event.window.event == SDL_WINDOWEVENT_EXPOSED) {
-
-						Emulator->RefreshDisplay();
-					}
-					break;
-
-				default:
-					break;
-			}
-		}
-
-		while (SDL_GetTicks() < nextTick)
-			SDL_Delay(1);
-	}
-
-	defaultSurface = LockSurface(defaultTexture);
-
-	menuStackLevel--;
-	if (menuStackLevel >= 0) {
-		memcpy(defaultSurface->pixels, menuStack[menuStackLevel].frame, frameLength);
-		delete [] menuStack[menuStackLevel].frame;
-		menuStack[menuStackLevel].frame = NULL;
-	}
-	else
-		memset(defaultSurface->pixels, 0, frameLength);
-
-	UnlockSurface(defaultTexture, defaultSurface);
-
-	SDL_Delay(GPU_TIMER_INTERVAL);
-	needRelease = true;
 }
 //-----------------------------------------------------------------------------
-BYTE UserInterface::QueryDialog(const char *title, bool save)
+void UserInterface::QueryDialog(const char *title, bool save)
 {
 	void *data = (save) ? gui_query_save : gui_query_confirm;
 	char *dialogTitle = new char[strlen(title) + 5];
@@ -178,146 +125,70 @@ BYTE UserInterface::QueryDialog(const char *title, bool save)
 	sprintf(dialogTitle, "  %s  ", title);
 	((GUI_MENU_ENTRY *) data)->text = (const char *) dialogTitle;
 
-	GUI_SURFACE *defaultSurface = LockSurface(defaultTexture);
-	if (menuStackLevel < 0)
-		memset(defaultSurface->pixels, 0, frameLength);
-	else {
-		menuStack[menuStackLevel].frame = new BYTE[frameLength];
-		memcpy(menuStack[menuStackLevel].frame, defaultSurface->pixels, frameLength);
-	}
-	UnlockSurface(defaultTexture, defaultSurface);
+	MenuOpen(GUI_TYPE_QUERY_DIALOG, data);
+}
+//-----------------------------------------------------------------------------
+void UserInterface::KeyhandlerQueryDialog(WORD key)
+{
+	GUI_MENU_ENTRY *ptr = &cMenu_data[cMenu_hilite + 1];
+	bool change = false;
 
-	GUI_MENU_ENTRY *bkm_data = cMenu_data;
-	SDL_Rect *bkm_rect = new SDL_Rect(*cMenu_rect);
-	int bkm_leftMargin = cMenu_leftMargin,
-		bkm_hilite = cMenu_hilite,
-		bkm_count = cMenu_count;
+	switch (key) {
+		case SDL_SCANCODE_ESCAPE:
+			uiQueryState = GUI_QUERY_CANCEL;
+			MenuClose();
+			return;
 
-	menuStackLevel++;
-	menuStack[menuStackLevel].type = GUI_TYPE_MENU;
-	menuStack[menuStackLevel].data = data;
-	menuStack[menuStackLevel].hilite = cMenu_hilite = (save) ? 2 : 1;
-	menuStack[menuStackLevel].frame = NULL;
+		case SDL_SCANCODE_RETURN:
+		case SDL_SCANCODE_KP_ENTER:
+			uiQueryState = ptr->action;
+			MenuClose();
+			return;
 
-	DrawMenu(data);
-
-	bool change;
-	DWORD nextTick;
-	SDL_Event event;
-	GUI_MENU_ENTRY *ptr;
-	uiQueryState = GUI_QUERY_NONE;
-
-	SDL_Delay(GPU_TIMER_INTERVAL);
-	while (uiQueryState == GUI_QUERY_NONE) {
-		nextTick = SDL_GetTicks() + CPU_TIMER_INTERVAL;
-
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					ptr = &cMenu_data[cMenu_hilite + 1];
-					change = false;
-
-					switch (event.key.keysym.scancode) {
-						case SDL_SCANCODE_ESCAPE:
-							uiQueryState = GUI_QUERY_CANCEL;
-							break;
-
-						case SDL_SCANCODE_RETURN:
-						case SDL_SCANCODE_KP_ENTER:
-							uiQueryState = ptr->action;
-							break;
-
-						case SDL_SCANCODE_Y:
-							if (!save) {
-								uiQueryState = cMenu_data[1].action;
-							}
-							break;
-
-						case SDL_SCANCODE_N:
-							if (!save) {
-								uiQueryState = cMenu_data[2].action;
-							}
-							break;
-
-						case SDL_SCANCODE_UP:
-							if (cMenu_hilite > 0) {
-								cMenu_hilite--;
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_DOWN:
-							if (cMenu_hilite < (cMenu_count - 1)) {
-								cMenu_hilite++;
-								change = true;
-							}
-							break;
-
-						default:
-							break;
-					}
-
-					if (change) {
-						DrawMenuItems();
-						break;
-					}
-
-					for (ptr = &cMenu_data[1]; ptr->type != MENU_END; ptr++) {
-						if (event.key.keysym.sym == ptr->key) {
-							uiQueryState = ptr->action;
-							break;
-						}
-					}
-					break;
-
-				case SDL_WINDOWEVENT:
-					if (event.window.windowID == gdc.windowID &&
-						event.window.event == SDL_WINDOWEVENT_EXPOSED) {
-
-						Emulator->RefreshDisplay();
-					}
-					break;
-
-				default:
-					break;
+		case SDL_SCANCODE_Y:
+			if (cMenu_data[2].action != GUI_QUERY_SAVE) {
+				uiQueryState = cMenu_data[1].action;
+				MenuClose();
 			}
+			return;
+
+		case SDL_SCANCODE_N:
+			if (cMenu_data[2].action != GUI_QUERY_SAVE) {
+				uiQueryState = cMenu_data[2].action;
+				MenuClose();
+			}
+			return;
+
+		case SDL_SCANCODE_UP:
+			if (cMenu_hilite > 0) {
+				cMenu_hilite--;
+				change = true;
+			}
+			break;
+
+		case SDL_SCANCODE_DOWN:
+			if (cMenu_hilite < (cMenu_count - 1)) {
+				cMenu_hilite++;
+				change = true;
+			}
+			break;
+
+		default:
+			break;
+	}
+
+	if (change) {
+		DrawMenuItems();
+		return;
+	}
+
+	for (ptr = &cMenu_data[1]; ptr->type != MENU_END; ptr++) {
+		if (key == ptr->key) {
+			uiQueryState = ptr->action;
+			MenuClose();
+			return;
 		}
-
-		while (SDL_GetTicks() < nextTick)
-			SDL_Delay(1);
 	}
-
-	defaultSurface = LockSurface(defaultTexture);
-
-	menuStackLevel--;
-	if (menuStackLevel >= 0) {
-		memcpy(defaultSurface->pixels, menuStack[menuStackLevel].frame, frameLength);
-		delete [] menuStack[menuStackLevel].frame;
-		menuStack[menuStackLevel].frame = NULL;
-	}
-	else
-		memset(defaultSurface->pixels, 0, frameLength);
-
-	UnlockSurface(defaultTexture, defaultSurface);
-
-	needRelease = true;
-
-	((GUI_MENU_ENTRY *) data)->text = NULL;
-	delete [] dialogTitle;
-
-	cMenu_rect->x = bkm_rect->x;
-	cMenu_rect->y = bkm_rect->y;
-	cMenu_rect->w = bkm_rect->w;
-	cMenu_rect->h = bkm_rect->h;
-	delete bkm_rect;
-
-	cMenu_data = bkm_data;
-	cMenu_leftMargin = bkm_leftMargin;
-	cMenu_hilite = bkm_hilite;
-	cMenu_count = bkm_count;
-
-	SDL_Delay(GPU_TIMER_INTERVAL);
-	return uiQueryState;
 }
 //-----------------------------------------------------------------------------
 void UserInterface::MessageBox(const char *text, ...)
@@ -337,6 +208,10 @@ void UserInterface::MessageBox(const char *text, ...)
 	}
 
 	menuStackLevel++;
+	menuStack[menuStackLevel].type = GUI_TYPE_MESSAGE_BOX;
+	menuStack[menuStackLevel].data = NULL;
+	menuStack[menuStackLevel].frame = NULL;
+	menuStack[menuStackLevel].hilite = 0;
 
 	unsigned i, w = 0, h = fontLineHeight, x, y;
 	for (i = 0, x = 0; i < strlen(msgbuffer); i++) {
@@ -376,62 +251,21 @@ void UserInterface::MessageBox(const char *text, ...)
 			y + GUI_CONST_BORDER + 1, GUI_COLOR_FOREGROUND, msgbuffer);
 
 	UnlockSurface(defaultTexture, defaultSurface);
-	SDL_Delay(GPU_TIMER_INTERVAL);
-
-	i = 1;
-	DWORD nextTick;
-	SDL_Event event;
-
-	while (i) {
-		nextTick = SDL_GetTicks() + CPU_TIMER_INTERVAL;
-
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					switch (event.key.keysym.scancode) {
-						case SDL_SCANCODE_SPACE:
-						case SDL_SCANCODE_ESCAPE:
-						case SDL_SCANCODE_RETURN:
-						case SDL_SCANCODE_KP_ENTER:
-							i = 0;
-							break;
-
-						default:
-							break;
-					}
-					break;
-
-				case SDL_WINDOWEVENT:
-					if (event.window.windowID == gdc.windowID &&
-						event.window.event == SDL_WINDOWEVENT_EXPOSED) {
-
-						Emulator->RefreshDisplay();
-					}
-					break;
-
-				default:
-					break;
-			}
-		}
-
-		while (SDL_GetTicks() < nextTick)
-			SDL_Delay(1);
-	}
-
-	defaultSurface = LockSurface(defaultTexture);
-
-	menuStackLevel--;
-	if (menuStackLevel >= 0) {
-		memcpy(defaultSurface->pixels, menuStack[menuStackLevel].frame, frameLength);
-		delete [] menuStack[menuStackLevel].frame;
-		menuStack[menuStackLevel].frame = NULL;
-	}
-	else
-		memset(defaultSurface->pixels, 0, frameLength);
-
-	UnlockSurface(defaultTexture, defaultSurface);
-
-	SDL_Delay(GPU_TIMER_INTERVAL);
 	needRelease = true;
+}
+//-----------------------------------------------------------------------------
+void UserInterface::KeyhandlerCommonDialog(WORD key)
+{
+	switch (key) {
+		case SDL_SCANCODE_SPACE:
+		case SDL_SCANCODE_ESCAPE:
+		case SDL_SCANCODE_RETURN:
+		case SDL_SCANCODE_KP_ENTER:
+			MenuClose();
+			break;
+
+		default:
+			break;
+	}
 }
 //-----------------------------------------------------------------------------

--- a/gui/CommonDialog.cpp
+++ b/gui/CommonDialog.cpp
@@ -117,7 +117,7 @@ void UserInterface::AboutDialog()
 	UnlockSurface(defaultTexture, defaultSurface);
 }
 //-----------------------------------------------------------------------------
-void UserInterface::QueryDialog(const char *title, bool save)
+BYTE UserInterface::QueryDialog(const char *title, bool save)
 {
 	void *data = (save) ? gui_query_save : gui_query_confirm;
 	char *dialogTitle = new char[strlen(title) + 5];
@@ -126,6 +126,9 @@ void UserInterface::QueryDialog(const char *title, bool save)
 	((GUI_MENU_ENTRY *) data)->text = (const char *) dialogTitle;
 
 	MenuOpen(GUI_TYPE_QUERY_DIALOG, data);
+
+	// TODO FIXME
+	return GUI_QUERY_NONE;
 }
 //-----------------------------------------------------------------------------
 void UserInterface::KeyhandlerQueryDialog(WORD key)

--- a/gui/EditDialog.cpp
+++ b/gui/EditDialog.cpp
@@ -18,10 +18,18 @@
 #include "UserInterface.h"
 #include "Emulator.h"
 //-----------------------------------------------------------------------------
-BYTE UserInterface::EditBox(const char *title, const char *description, char *buffer, BYTE maxLength, bool decimal)
+void UserInterface::EditBox(const char *title, const char *description, char *buffer, BYTE maxLength, bool decimal)
 {
 	if (maxLength <= 0 || maxLength > (maxCharsOnScreen - 2))
 		maxLength = maxCharsOnScreen - 2;
+
+	editBox->buffer = buffer;
+	editBox->maxLength = maxLength;
+	editBox->decimal = decimal;
+	editBox->len = strlen(buffer);
+	editBox->cursor = editBox->len;
+	editBox->result = (BYTE) -1;
+	editBox->atTheEnd = true;
 
 	GUI_SURFACE *defaultSurface = LockSurface(defaultTexture);
 
@@ -33,204 +41,159 @@ BYTE UserInterface::EditBox(const char *title, const char *description, char *bu
 	}
 
 	menuStackLevel++;
-	menuStack[menuStackLevel].type = GUI_TYPE_MENU;
-	menuStack[menuStackLevel].hilite = 0;
-	menuStack[menuStackLevel].data = NULL;
+	menuStack[menuStackLevel].type = GUI_TYPE_EDITBOX;
+	menuStack[menuStackLevel].data = editBox;
 	menuStack[menuStackLevel].frame = NULL;
+	menuStack[menuStackLevel].hilite = 0;
 
-	WORD i, len = strlen(buffer), cursor = len,
-		w = (strlen(title) + 4) * fontWidth, h, x, y;
+	editBox->w = (strlen(title) + 4) * fontWidth;
+	editBox->h = (4 * GUI_CONST_BORDER);
 
-	if (description != NULL && w < ((strlen(description) + 4) * fontWidth))
-		w = (strlen(description) + 4) * fontWidth;
-	if (w < ((maxLength + 1) * fontWidth))
-		w = ((maxLength + 1) * fontWidth);
-
-	w = (2 * GUI_CONST_BORDER) + w;
-	h = (4 * GUI_CONST_BORDER);
-	x = (frameWidth  - w) / 2;
-	y = (frameHeight - h) / 2;
-
+	if (description != NULL && editBox->w < ((strlen(description) + 4) * fontWidth))
+		editBox->w = (strlen(description) + 4) * fontWidth;
+	if (editBox->w < ((editBox->maxLength + 1) * fontWidth))
+		editBox->w = ((editBox->maxLength + 1) * fontWidth);
+	editBox->w = (2 * GUI_CONST_BORDER) + editBox->w;
 	if (description != NULL)
-		h += (2 * GUI_CONST_BORDER);
+		editBox->h += (2 * GUI_CONST_BORDER);
+	editBox->x = (frameWidth  - editBox->w) / 2;
+	editBox->y = (frameHeight - editBox->h) / 2;
 
-	DrawDialogWithBorder(defaultSurface, x, y, w, h);
-	PrintTitle(defaultSurface, x, y + 1, w, GUI_COLOR_BACKGROUND, title);
+	DrawDialogWithBorder(defaultSurface, editBox->x, editBox->y, editBox->w, editBox->h);
+	PrintTitle(defaultSurface, editBox->x, editBox->y + 1, editBox->w, GUI_COLOR_BACKGROUND, title);
 
-	x += GUI_CONST_BORDER;
-	y += (2 * GUI_CONST_BORDER);
-	w -= (2 * GUI_CONST_BORDER);
+	editBox->x += GUI_CONST_BORDER;
+	editBox->y += (2 * GUI_CONST_BORDER);
+	editBox->w -= (2 * GUI_CONST_BORDER);
 
-	if (description != NULL) {
-		PrintText(defaultSurface, x, y, GUI_COLOR_DISABLED, description);
-		y += (2 * GUI_CONST_BORDER);
+	if (editBox->description != NULL) {
+		PrintText(defaultSurface, editBox->x, editBox->y, GUI_COLOR_DISABLED, editBox->description);
+		editBox->y += (2 * GUI_CONST_BORDER);
 	}
+}
+//-----------------------------------------------------------------------------
+void UserInterface::KeyhandlerEditBox(WORD key)
+{
+	bool change = false;
 
-	UnlockSurface(defaultTexture, defaultSurface);
+	switch (key) {
+		case SDL_SCANCODE_ESCAPE:
+			editBox->result = 0;
+			editBox->callback(editBox->buffer, editBox->result);
+			MenuClose();
+			break;
 
-	DWORD nextTick;
-	BYTE result = -1;
-	SDL_Event event;
-	bool atTheEnd = true, change = true;
+		case SDL_SCANCODE_RETURN:
+		case SDL_SCANCODE_KP_ENTER:
+			// trim left
+			editBox->cursor = 0;
+			while (editBox->buffer[editBox->cursor] == ' ')
+				editBox->cursor++;
 
-	SDL_Delay(GPU_TIMER_INTERVAL);
-	while (result == (BYTE) -1) {
-		nextTick = SDL_GetTicks() + CPU_TIMER_INTERVAL;
+			if (editBox->cursor > 0)
+				for (int i = 0; editBox->cursor <= editBox->len; i++, editBox->cursor++)
+					editBox->buffer[i] = editBox->buffer[editBox->cursor];
 
-		while (SDL_PollEvent(&event)) {
-			switch (event.type) {
-				case SDL_KEYDOWN:
-					switch (event.key.keysym.scancode) {
-						case SDL_SCANCODE_ESCAPE:
-							result = 0;
-							break;
+			// trim right
+			editBox->cursor = (editBox->len = strlen(editBox->buffer)) - 1;
+			while (editBox->buffer[editBox->cursor] == ' ')
+				editBox->cursor--;
 
-						case SDL_SCANCODE_RETURN:
-						case SDL_SCANCODE_KP_ENTER:
-							// trim left
-							cursor = 0;
-							while (buffer[cursor] == ' ')
-								cursor++;
+			if (++editBox->cursor < editBox->len)
+				editBox->buffer[editBox->cursor] = '\0';
 
-							if (cursor > 0)
-								for (i = 0; cursor <= len; i++, cursor++)
-									buffer[i] = buffer[cursor];
+			editBox->result = 1;
+			MenuClose();
+			break;
 
-							// trim right
-							cursor = (len = strlen(buffer)) - 1;
-							while (buffer[cursor] == ' ')
-								cursor--;
-
-							if (++cursor < len)
-								buffer[cursor] = '\0';
-
-							result = 1;
-							break;
-
-						case SDL_SCANCODE_LEFT:
-							if (cursor > 0) {
-								cursor--;
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_RIGHT:
-							if (!atTheEnd) {
-								cursor++;
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_BACKSPACE:
-							if (cursor > 0) {
-								cursor--;
-								for (i = cursor; i < len; i++)
-									buffer[i] = buffer[i + 1];
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_INSERT:
-							if (!atTheEnd && len < maxLength) {
-								for (i = len + 1; i > cursor; i--)
-									buffer[i] = buffer[i - 1];
-								buffer[cursor] = ' ';
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_DELETE:
-							if (!atTheEnd) {
-								for (i = cursor; i < len; i++)
-									buffer[i] = buffer[i + 1];
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_HOME:
-							if (cursor > 0) {
-								cursor = 0;
-								change = true;
-							}
-							break;
-
-						case SDL_SCANCODE_END:
-							if (!atTheEnd) {
-								cursor = len;
-								change = true;
-							}
-							break;
-
-						default:
-							if (event.key.keysym.sym < SDLK_SPACE
-							 || event.key.keysym.sym > 0x007E)
-								break;
-
-							char c = (char) event.key.keysym.sym & 0x7f;
-							if (cursor < maxLength) {
-								if (decimal && (c < '0' || c > '9'))
-									break;
-
-								buffer[cursor] = c;
-								cursor++;
-								if (atTheEnd)
-									buffer[cursor] = '\0';
-
-								change = true;
-							}
-							break;
-					}
-					break;
-
-				case SDL_WINDOWEVENT:
-					if (event.window.windowID == gdc.windowID &&
-						event.window.event == SDL_WINDOWEVENT_EXPOSED) {
-
-						Emulator->RefreshDisplay();
-					}
-					break;
-
-				default:
-					break;
+		case SDL_SCANCODE_LEFT:
+			if (editBox->cursor > 0) {
+				editBox->cursor--;
+				change = true;
 			}
+			break;
 
-			if (change) {
-				defaultSurface = LockSurface(defaultTexture);
+		case SDL_SCANCODE_RIGHT:
+			if (!editBox->atTheEnd) {
+				editBox->cursor++;
+				change = true;
+			}
+			break;
 
-				DrawRectangle(defaultSurface, x, y - 1, w, fontHeight + 1,
-					GUI_COLOR_BACKGROUND);
-				DrawRectangle(defaultSurface, x + (cursor * fontWidth), y - 1,
-					fontWidth, fontHeight + 1, GUI_COLOR_HIGHLIGHT);
-				PrintText(defaultSurface, x, y, GUI_COLOR_FOREGROUND, buffer);
+		case SDL_SCANCODE_BACKSPACE:
+			if (editBox->cursor > 0) {
+				editBox->cursor--;
+				for (int i = editBox->cursor; i < editBox->len; i++)
+					editBox->buffer[i] = editBox->buffer[i + 1];
+				change = true;
+			}
+			break;
 
-				len = strlen(buffer);
-				atTheEnd = (cursor == len);
+		case SDL_SCANCODE_INSERT:
+			if (!editBox->atTheEnd && editBox->len < editBox->maxLength) {
+				for (int i = editBox->len + 1; i > editBox->cursor; i--)
+					editBox->buffer[i] = editBox->buffer[i - 1];
+				editBox->buffer[editBox->cursor] = ' ';
+				change = true;
+			}
+			break;
 
-				UnlockSurface(defaultTexture, defaultSurface);
-				change = false;
+		case SDL_SCANCODE_DELETE:
+			if (!editBox->atTheEnd) {
+				for (int i = editBox->cursor; i < editBox->len; i++)
+					editBox->buffer[i] = editBox->buffer[i + 1];
+				change = true;
+			}
+			break;
+
+		case SDL_SCANCODE_HOME:
+			if (editBox->cursor > 0) {
+				editBox->cursor = 0;
+				change = true;
+			}
+			break;
+
+		case SDL_SCANCODE_END:
+			if (!editBox->atTheEnd) {
+				editBox->cursor = editBox->len;
+				change = true;
+			}
+			break;
+
+		default:
+			if (key < SDLK_SPACE || key > 0x007E)
 				break;
+
+			char c = (char) key & 0x7f;
+			if (editBox->cursor < editBox->maxLength) {
+				if (editBox->decimal && (c < '0' || c > '9'))
+					break;
+
+				editBox->buffer[editBox->cursor] = c;
+				editBox->cursor++;
+				if (editBox->atTheEnd)
+					editBox->buffer[editBox->cursor] = '\0';
+
+				change = true;
 			}
-		}
-
-		while (SDL_GetTicks() < nextTick)
-			SDL_Delay(1);
+			break;
 	}
 
-	defaultSurface = LockSurface(defaultTexture);
+	if (change) {
+		GUI_SURFACE *defaultSurface = LockSurface(defaultTexture);
 
-	menuStackLevel--;
-	if (menuStackLevel >= 0) {
-		memcpy(defaultSurface->pixels, menuStack[menuStackLevel].frame, frameLength);
-		delete [] menuStack[menuStackLevel].frame;
-		menuStack[menuStackLevel].frame = NULL;
+		DrawRectangle(defaultSurface,
+			editBox->x, editBox->y - 1, editBox->w, fontHeight + 1, GUI_COLOR_BACKGROUND);
+		DrawRectangle(defaultSurface,
+			editBox->x + (editBox->cursor * fontWidth), editBox->y - 1,
+			fontWidth, fontHeight + 1, GUI_COLOR_HIGHLIGHT);
+		PrintText(defaultSurface,
+			editBox->x, editBox->y, GUI_COLOR_FOREGROUND, editBox->buffer);
+
+		editBox->len = strlen(editBox->buffer);
+		editBox->atTheEnd = (editBox->cursor == editBox->len);
+
+		UnlockSurface(defaultTexture, defaultSurface);
 	}
-	else
-		memset(defaultSurface->pixels, 0, frameLength);
-
-	UnlockSurface(defaultTexture, defaultSurface);
-	SDL_Delay(GPU_TIMER_INTERVAL);
-
-	needRelease = true;
-	return result;
 }
 //-----------------------------------------------------------------------------

--- a/gui/EditDialog.cpp
+++ b/gui/EditDialog.cpp
@@ -47,7 +47,7 @@ void UserInterface::EditBox(const char *title, const char *description, char *bu
 	menuStack[menuStackLevel].hilite = 0;
 
 	editBox->w = (strlen(title) + 4) * fontWidth;
-	editBox->h = (4 * GUI_CONST_BORDER);
+	WORD h = (4 * GUI_CONST_BORDER);
 
 	if (description != NULL && editBox->w < ((strlen(description) + 4) * fontWidth))
 		editBox->w = (strlen(description) + 4) * fontWidth;
@@ -55,19 +55,19 @@ void UserInterface::EditBox(const char *title, const char *description, char *bu
 		editBox->w = ((editBox->maxLength + 1) * fontWidth);
 	editBox->w = (2 * GUI_CONST_BORDER) + editBox->w;
 	if (description != NULL)
-		editBox->h += (2 * GUI_CONST_BORDER);
+		h += (2 * GUI_CONST_BORDER);
 	editBox->x = (frameWidth  - editBox->w) / 2;
-	editBox->y = (frameHeight - editBox->h) / 2;
+	editBox->y = (frameHeight - h) / 2;
 
-	DrawDialogWithBorder(defaultSurface, editBox->x, editBox->y, editBox->w, editBox->h);
+	DrawDialogWithBorder(defaultSurface, editBox->x, editBox->y, editBox->w, h);
 	PrintTitle(defaultSurface, editBox->x, editBox->y + 1, editBox->w, GUI_COLOR_BACKGROUND, title);
 
 	editBox->x += GUI_CONST_BORDER;
 	editBox->y += (2 * GUI_CONST_BORDER);
 	editBox->w -= (2 * GUI_CONST_BORDER);
 
-	if (editBox->description != NULL) {
-		PrintText(defaultSurface, editBox->x, editBox->y, GUI_COLOR_DISABLED, editBox->description);
+	if (description != NULL) {
+		PrintText(defaultSurface, editBox->x, editBox->y, GUI_COLOR_DISABLED, description);
 		editBox->y += (2 * GUI_CONST_BORDER);
 	}
 }
@@ -79,7 +79,6 @@ void UserInterface::KeyhandlerEditBox(WORD key)
 	switch (key) {
 		case SDL_SCANCODE_ESCAPE:
 			editBox->result = 0;
-			editBox->callback(editBox->buffer, editBox->result);
 			MenuClose();
 			break;
 

--- a/gui/FileSelector.cpp
+++ b/gui/FileSelector.cpp
@@ -266,40 +266,12 @@ void UserInterface::KeyhandlerFileSelector(WORD key)
 				if (*ptr == '\xA0')
 					strcpy(buffer, ptr + 1);
 
-				if (EditBox("ENTER FILENAME:", NULL, buffer, 32, false) && strlen(buffer) > 0) {
-					for (b = 0; b < strlen(buffer); b++) {
-						switch (buffer[b]) {
-						// multiplatform restricted characters in filenames;
-						// filtering to avoid file portability problems;
-							case ' ':  case '/':  case '\\': case '?':
-							case '*':  case '%':  case ':':  case '|':
-							case '"':  case '<':  case '>':
-								buffer[b] = '_';
-								break;
+				fileSelector->callbackShouldExit = false;
+				editBox->callback.connect(this, &UserInterface::EditBoxFileSelectorCallback);
+				EditBox("ENTER FILENAME:", NULL, buffer, 32, false);
 
-							default:
-								break;
-						}
-					}
-
-					if (fileSelector->extFilter) {
-						if ((ptr = strrchr(buffer, '.'))) {
-							for (b = 0; fileSelector->extFilter[b] != NULL; b++) {
-								if (strcasecmp(ptr + 1, fileSelector->extFilter[b]) == 0) {
-									KeyhandlerFileSelectorCallback(buffer);
-									return;
-								}
-							}
-						}
-
-						ptr = buffer + strlen(buffer);
-						*ptr = '.';
-						strcpy(ptr + 1, fileSelector->extFilter[0]);
-					}
-
-					KeyhandlerFileSelectorCallback(buffer);
+				if (fileSelector->callbackShouldExit)
 					return;
-				}
 			}
 			break;
 
@@ -502,6 +474,47 @@ void UserInterface::KeyhandlerFileSelector(WORD key)
 		cMenu_hilite = i;
 		DrawFileSelectorItems();
 	}
+}
+//-----------------------------------------------------------------------------
+void UserInterface::EditBoxFileSelectorCallback(char *buffer, BYTE result)
+{
+	if (result == 0 && strlen(buffer) <= 0)
+		return;
+
+	char *ptr;
+	for (int b = 0; b < strlen(buffer); b++) {
+		switch (buffer[b]) {
+		// multiplatform restricted characters in filenames;
+		// filtering to avoid file portability problems;
+			case ' ':  case '/':  case '\\': case '?':
+			case '*':  case '%':  case ':':  case '|':
+			case '"':  case '<':  case '>':
+				buffer[b] = '_';
+				break;
+
+			default:
+				break;
+		}
+	}
+
+	if (fileSelector->extFilter) {
+		if ((ptr = strrchr(buffer, '.'))) {
+			for (int b = 0; fileSelector->extFilter[b] != NULL; b++) {
+				if (strcasecmp(ptr + 1, fileSelector->extFilter[b]) == 0) {
+					KeyhandlerFileSelectorCallback(buffer);
+					fileSelector->callbackShouldExit = true;
+					return;
+				}
+			}
+		}
+
+		ptr = buffer + strlen(buffer);
+		*ptr = '.';
+		strcpy(ptr + 1, fileSelector->extFilter[0]);
+	}
+
+	KeyhandlerFileSelectorCallback(buffer);
+	fileSelector->callbackShouldExit = true;
 }
 //-----------------------------------------------------------------------------
 void UserInterface::KeyhandlerFileSelectorCallback(char *fileName)

--- a/gui/UserInterface.cpp
+++ b/gui/UserInterface.cpp
@@ -107,6 +107,7 @@ UserInterface::UserInterface()
 
 	cMenu_data = NULL;
 	cMenu_rect = new SDL_Rect;
+	SDL_zero(cMenuPopup);
 
 	fileSelector = new GUI_FILESELECTOR_DATA;
 	fileSelector->dirEntries = NULL;
@@ -119,7 +120,18 @@ UserInterface::UserInterface()
 	tapeDialog = new GUI_TAPEDIALOG_DATA;
 	tapeDialog->entries = NULL;
 	tapeDialog->count = 0;
-	tapeDialog->popup.rect = NULL;
+
+	editData = new GUI_EDITBOX_DATA;
+	editData->title = NULL;
+	editData->description = NULL;
+	editData->buffer = msgbuffer;
+	editData->maxLength = 0;
+	editData->decimal = true;
+	editData->len = 0;
+	editData->cursor = 0;
+	editData->result = (BYTE) -1;
+	editData->atTheEnd = true;
+	editData->change = false;
 
 	ledState = 0;
 	iconState = 0;
@@ -156,6 +168,7 @@ UserInterface::~UserInterface()
 
 	if (fileSelector) {
 		ScanDir(NULL, &fileSelector->dirEntries, &fileSelector->count);
+		fileSelector->callback.disconnect_all();
 		delete fileSelector;
 		fileSelector = NULL;
 	}
@@ -473,14 +486,15 @@ void UserInterface::MenuOpen(GUI_MENU_TYPE type, void *data)
 		menuStack[menuStackLevel].frame = new BYTE[frameLength];
 		memcpy(menuStack[menuStackLevel].frame, defaultSurface->pixels, frameLength);
 
-		if (type == GUI_TYPE_TAPE_POPUP) {
-			if (tapeDialog->popup.rect)
-				delete tapeDialog->popup.rect;
+		if (type == GUI_TYPE_TAPE_POPUP || type == GUI_TYPE_QUERY_DIALOG) {
+			if (cMenuPopup.rect)
+				delete cMenuPopup.rect;
 
-			tapeDialog->popup.rect = new SDL_Rect(*cMenu_rect);
-			tapeDialog->popup.count = cMenu_count;
-			tapeDialog->popup.hilite = cMenu_hilite;
-			tapeDialog->popup.leftMargin = cMenu_leftMargin;
+			cMenuPopup.rect = new SDL_Rect(*cMenu_rect);
+			cMenuPopup.count = cMenu_count;
+			cMenuPopup.hilite = cMenu_hilite;
+			cMenuPopup.leftMargin = cMenu_leftMargin;
+			cMenuPopup.set = true;
 		}
 		else
 			menuStack[menuStackLevel].hilite = cMenu_hilite;
@@ -497,6 +511,7 @@ void UserInterface::MenuOpen(GUI_MENU_TYPE type, void *data)
 	switch (type) {
 		case GUI_TYPE_MENU:
 		case GUI_TYPE_TAPE_POPUP:
+		case GUI_TYPE_QUERY_DIALOG:
 			DrawMenu(data);
 			break;
 
@@ -526,6 +541,14 @@ void UserInterface::MenuClose()
 
 	GUI_SURFACE *defaultSurface = LockSurface(defaultTexture);
 
+	if (menuStack[menuStackLevel].type == GUI_TYPE_QUERY_DIALOG) {
+		void *data = menuStack[menuStackLevel].data;
+		char *queryDialogTitle = ((GUI_MENU_ENTRY *) data)->text;
+		if (queryDialogTitle)
+			delete [] queryDialogTitle;
+		((GUI_MENU_ENTRY *) data)->text = NULL;
+	}
+
 	menuStack[menuStackLevel].data = NULL;
 	menuStackLevel--;
 	if (menuStackLevel >= 0) {
@@ -535,25 +558,26 @@ void UserInterface::MenuClose()
 		delete [] menuStack[menuStackLevel].frame;
 		menuStack[menuStackLevel].frame = NULL;
 
-		if (menuStack[menuStackLevel + 1].type == GUI_TYPE_TAPE_POPUP) {
-			cMenu_rect->x = tapeDialog->popup.rect->x;
-			cMenu_rect->y = tapeDialog->popup.rect->y;
-			cMenu_rect->w = tapeDialog->popup.rect->w;
-			cMenu_rect->h = tapeDialog->popup.rect->h;
-			cMenu_count = tapeDialog->popup.count;
-			cMenu_hilite = tapeDialog->popup.hilite;
-			cMenu_leftMargin = tapeDialog->popup.leftMargin;
+		GUI_MENU_TYPE lastType = menuStack[menuStackLevel + 1].type;
+		if ((lastType == GUI_TYPE_TAPE_POPUP || lastType == GUI_TYPE_QUERY_DIALOG) && cMenuPopup.set) {
+			cMenu_rect->x = cMenuPopup.rect->x;
+			cMenu_rect->y = cMenuPopup.rect->y;
+			cMenu_rect->w = cMenuPopup.rect->w;
+			cMenu_rect->h = cMenuPopup.rect->h;
+			cMenu_count = cMenuPopup.count;
+			cMenu_hilite = cMenuPopup.hilite;
+			cMenu_leftMargin = cMenuPopup.leftMargin;
 
-			if (tapeDialog->popup.rect)
-				delete tapeDialog->popup.rect;
+			if (cMenuPopup.rect)
+				delete cMenuPopup.rect;
 
-			tapeDialog->popup.rect = NULL;
-			tapeDialog->popup.count = -1;
-			tapeDialog->popup.hilite = -1;
-			tapeDialog->popup.leftMargin = -1;
-
+			SDL_zero(cMenuPopup);
 			needRelease = true;
 			return;
+		}
+		else if (lastType == GUI_TYPE_EDITBOX) {
+			GUI_EDITBOX_DATA *editBoxData = (GUI_EDITBOX_DATA *) menuStack[menuStackLevel + 1].data;
+			editBoxData->callback.disconnect_all();
 		}
 		else
 			cMenu_hilite = menuStack[menuStackLevel].hilite;
@@ -583,20 +607,23 @@ void UserInterface::MenuCloseAll()
 	SDL_Delay(GUI_CONST_KEY_REPEAT);
 
 	for (int i = menuStackLevel; i >= 0; i--) {
-		if (menuStack[i].type == GUI_TYPE_TAPE_POPUP) {
-			if (tapeDialog->popup.rect)
-				delete tapeDialog->popup.rect;
-
-			tapeDialog->popup.rect = NULL;
-			tapeDialog->popup.count = -1;
-			tapeDialog->popup.hilite = -1;
-			tapeDialog->popup.leftMargin = -1;
+		if (menuStack[i].type == GUI_TYPE_QUERY_DIALOG) {
+			void *data = menuStack[i].data;
+			char *queryDialogTitle = ((GUI_MENU_ENTRY *) data)->text;
+			if (queryDialogTitle)
+				delete [] queryDialogTitle;
+			((GUI_MENU_ENTRY *) data)->text = NULL;
 		}
-
 		if (menuStack[i].frame)
 			delete [] menuStack[i].frame;
 		menuStack[i].frame = NULL;
 		menuStack[i].data = NULL;
+	}
+
+	if (cMenuPopup.set) {
+		if (cMenuPopup.rect)
+			delete cMenuPopup.rect;
+		SDL_zero(cMenuPopup);
 	}
 
 	GUI_SURFACE *defaultSurface = LockSurface(defaultTexture);
@@ -625,6 +652,19 @@ void UserInterface::MenuHandleKey(WORD key)
 
 			case GUI_TYPE_DEBUGGER:
 				KeyhandlerDebugWindow(key);
+				break;
+
+			case GUI_TYPE_ABOUT_DIALOG:
+			case GUI_TYPE_MESSAGE_BOX:
+				KeyhandlerCommonDialog(key);
+				break;
+
+			case GUI_TYPE_QUERY_DIALOG:
+				KeyhandlerQueryDialog(key);
+				break;
+
+			case GUI_TYPE_EDITBOX:
+				KeyhandlerEditBox(key);
 				break;
 
 			default:

--- a/gui/UserInterface.cpp
+++ b/gui/UserInterface.cpp
@@ -121,17 +121,14 @@ UserInterface::UserInterface()
 	tapeDialog->entries = NULL;
 	tapeDialog->count = 0;
 
-	editData = new GUI_EDITBOX_DATA;
-	editData->title = NULL;
-	editData->description = NULL;
-	editData->buffer = msgbuffer;
-	editData->maxLength = 0;
-	editData->decimal = true;
-	editData->len = 0;
-	editData->cursor = 0;
-	editData->result = (BYTE) -1;
-	editData->atTheEnd = true;
-	editData->change = false;
+	editBox = new GUI_EDITBOX_DATA;
+	editBox->buffer = msgbuffer;
+	editBox->maxLength = 0;
+	editBox->decimal = true;
+	editBox->len = 0;
+	editBox->cursor = 0;
+	editBox->result = (BYTE) -1;
+	editBox->atTheEnd = true;
 
 	ledState = 0;
 	iconState = 0;
@@ -543,7 +540,7 @@ void UserInterface::MenuClose()
 
 	if (menuStack[menuStackLevel].type == GUI_TYPE_QUERY_DIALOG) {
 		void *data = menuStack[menuStackLevel].data;
-		char *queryDialogTitle = ((GUI_MENU_ENTRY *) data)->text;
+		const char *queryDialogTitle = ((GUI_MENU_ENTRY *) data)->text;
 		if (queryDialogTitle)
 			delete [] queryDialogTitle;
 		((GUI_MENU_ENTRY *) data)->text = NULL;
@@ -577,6 +574,7 @@ void UserInterface::MenuClose()
 		}
 		else if (lastType == GUI_TYPE_EDITBOX) {
 			GUI_EDITBOX_DATA *editBoxData = (GUI_EDITBOX_DATA *) menuStack[menuStackLevel + 1].data;
+			editBoxData->callback(editBoxData->buffer, editBoxData->result);
 			editBoxData->callback.disconnect_all();
 		}
 		else
@@ -609,7 +607,7 @@ void UserInterface::MenuCloseAll()
 	for (int i = menuStackLevel; i >= 0; i--) {
 		if (menuStack[i].type == GUI_TYPE_QUERY_DIALOG) {
 			void *data = menuStack[i].data;
-			char *queryDialogTitle = ((GUI_MENU_ENTRY *) data)->text;
+			const char *queryDialogTitle = ((GUI_MENU_ENTRY *) data)->text;
 			if (queryDialogTitle)
 				delete [] queryDialogTitle;
 			((GUI_MENU_ENTRY *) data)->text = NULL;

--- a/gui/UserInterface.h
+++ b/gui/UserInterface.h
@@ -116,6 +116,7 @@ class UserInterface : public sigslot::has_slots<>
 			char **extFilter;
 			BYTE itemsOnPage;
 			BYTE tag;
+			bool callbackShouldExit;
 			sigslot::signal2<char *, BYTE *> callback;
 		} GUI_FILESELECTOR_DATA;
 
@@ -160,9 +161,10 @@ class UserInterface : public sigslot::has_slots<>
 		inline bool InMenu() { return (menuStackLevel >= 0); }
 
 		void AboutDialog();
-		void QueryDialog(const char *title, bool save);
+		BYTE QueryDialog(const char *title, bool save);
 		void MessageBox(const char *text, ...);
 		void EditBox(const char *title, const char *description, char *buffer, BYTE maxLength, bool decimal);
+		void EditBoxFileSelectorCallback(char *buffer, BYTE result);
 
 		void MenuOpen(GUI_MENU_TYPE type, void *data = NULL);
 		void MenuClose();

--- a/gui/UserInterface.h
+++ b/gui/UserInterface.h
@@ -99,7 +99,11 @@ class UserInterface : public sigslot::has_slots<>
 			GUI_TYPE_TAPEBROWSER,       // Tape-browser
 			GUI_TYPE_TAPE_POPUP,        // Tape-browser popup menu
 			GUI_TYPE_DEBUGGER,          // Debugger dialog
-			GUI_TYPE_POKE               // Poke dialog
+			GUI_TYPE_POKE,              // Poke dialog
+			GUI_TYPE_ABOUT_DIALOG,      // About dialog
+			GUI_TYPE_QUERY_DIALOG,      // Query dialog
+			GUI_TYPE_MESSAGE_BOX,       // MessageBox dialog
+			GUI_TYPE_EDITBOX            // EditBox dialog
 		};
 
 		typedef struct GUI_FILESELECTOR_DATA {
@@ -117,12 +121,22 @@ class UserInterface : public sigslot::has_slots<>
 
 		typedef struct GUI_TAPEDIALOG_DATA {
 			int  count;
+			int  hilite;
 			char **entries;
-			struct {
-				SDL_Rect *rect;
-				int leftMargin, count, hilite;
-			} popup;
 		} GUI_TAPEBROWSER_DATA;
+
+		typedef struct GUI_EDITBOX_DATA {
+			char *buffer;
+			BYTE maxLength;
+			bool decimal;
+
+			// state variables
+			WORD x, y, w, len, cursor;
+			BYTE result;
+			bool atTheEnd;
+
+			sigslot::signal2<char *, BYTE> callback;
+		} GUI_EDITBOX_DATA;
 
 		bool needRelease;
 		BYTE uiSetChanges;
@@ -136,7 +150,7 @@ class UserInterface : public sigslot::has_slots<>
 
 		GUI_FILESELECTOR_DATA *fileSelector;
 		GUI_TAPEDIALOG_DATA *tapeDialog;
-		sigslot::signal2<char *, BYTE *> editBoxValidator;
+		GUI_EDITBOX_DATA *editBox;
 
 		UserInterface();
 		virtual ~UserInterface();
@@ -146,9 +160,9 @@ class UserInterface : public sigslot::has_slots<>
 		inline bool InMenu() { return (menuStackLevel >= 0); }
 
 		void AboutDialog();
-		BYTE QueryDialog(const char *title, bool save);
+		void QueryDialog(const char *title, bool save);
 		void MessageBox(const char *text, ...);
-		BYTE EditBox(const char *title, const char *description, char *buffer, BYTE maxLength, bool decimal);
+		void EditBox(const char *title, const char *description, char *buffer, BYTE maxLength, bool decimal);
 
 		void MenuOpen(GUI_MENU_TYPE type, void *data = NULL);
 		void MenuClose();
@@ -202,6 +216,12 @@ class UserInterface : public sigslot::has_slots<>
 		SDL_Rect *cMenu_rect;
 		int cMenu_leftMargin, cMenu_count, cMenu_hilite;
 
+		struct {
+			bool set;
+			SDL_Rect *rect;
+			int leftMargin, count, hilite;
+		} cMenuPopup;
+
 		GUI_SURFACE *LoadImgToSurface(const char *file);
 		void BlitToSurface(GUI_SURFACE *src, const SDL_Rect *srcRect, GUI_SURFACE *dst, const SDL_Rect *dstRect);
 
@@ -235,6 +255,9 @@ class UserInterface : public sigslot::has_slots<>
 		void DrawDebugWidgetBreaks(GUI_SURFACE *s, SDL_Rect *r);
 		void DrawDebugWindow();
 		void KeyhandlerMenu(WORD key);
+		void KeyhandlerEditBox(WORD key);
+		void KeyhandlerQueryDialog(WORD key);
+		void KeyhandlerCommonDialog(WORD key);
 		void KeyhandlerFileSelector(WORD key);
 		void KeyhandlerFileSelectorCallback(char *fileName);
 		int  KeyhandlerFileSelectorSearch(int from = 0);

--- a/gui/UserInterfaceData.cpp
+++ b/gui/UserInterfaceData.cpp
@@ -40,7 +40,7 @@ const char *dcb_tape_contblk_state(GUI_MENU_ENTRY *ptr)
 		ptr->enabled = TapeBrowser->Selection->continuity;
 		if (TapeBrowser->Selection->total == 0) {
 			ptr->enabled = true;
-			f = l = GUI->tapeDialog->popup.hilite;
+			f = l = GUI->tapeDialog->hilite;
 		}
 
 		if ((i == SDL_SCANCODE_UP && f == 0) ||

--- a/gui/UserInterfaceData.cpp
+++ b/gui/UserInterfaceData.cpp
@@ -589,16 +589,8 @@ bool ccb_view_brdr(GUI_MENU_ENTRY *ptr)
 	WORD value = ((ptr) ? ptr->action : Settings->Screen->border);
 
 	sprintf(msgbuffer, "%d", value);
-	if (GUI->EditBox("CHANGE BORDER SIZE:", "(multiples of 8px)", msgbuffer, 1, true) == 1) {
-		value = strtol(msgbuffer, NULL, 10);
-		if (value == 0 && msgbuffer[0] != '0')
-			value = -1;
-
-		if (value >= 0 && value <= 9) {
-			Settings->Screen->border = (BYTE) value;
-			GUI->uiSetChanges |= PS_SCREEN_SIZE;
-		}
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionScreenBorderCallback);
+	GUI->EditBox("CHANGE BORDER SIZE:", "(multiples of 8px)", msgbuffer, 1, true);
 
 	return false;
 }
@@ -647,13 +639,8 @@ bool ccb_snd_volume(GUI_MENU_ENTRY *ptr)
 	WORD value = ((ptr) ? ptr->action : Settings->Sound->volume);
 
 	sprintf(msgbuffer, "%d", value);
-	if (GUI->EditBox("CHANGE VOLUME:", "(min=2, max=127)", msgbuffer, 3, true) == 1) {
-		value = strtol(msgbuffer, NULL, 10);
-		if (value > 1 && value <= 127) {
-			Settings->Sound->volume = (BYTE) value;
-			GUI->uiSetChanges |= PS_SOUND;
-		}
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionSoundVolumeCallback);
+	GUI->EditBox("CHANGE VOLUME:", "(min=2, max=127)", msgbuffer, 3, true);
 
 	return false;
 }
@@ -690,15 +677,8 @@ bool ccb_emu_speed(GUI_MENU_ENTRY *ptr)
 	WORD value = ((ptr) ? ptr->action : (Settings->emulationSpeed * 100.0f));
 
 	sprintf(msgbuffer, "%d", value);
-	if (GUI->EditBox("EMULATION SPEED:", "(enter 10% to 1000%)", msgbuffer, 4, true) == 1) {
-		value = strtol(msgbuffer, NULL, 10);
-		if (value == 0 && msgbuffer[0] != '0')
-			value = 100;
-		else if (value < 10 && value > 1000)
-			value = 100;
-
-		Settings->emulationSpeed = ((double) value / 100.0f);
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionEmulationSpeedCallback);
+	GUI->EditBox("EMULATION SPEED:", "(enter 10% to 1000%)", msgbuffer, 4, true);
 
 	return false;
 }
@@ -780,13 +760,8 @@ bool ccb_mem_mrmpage(GUI_MENU_ENTRY *ptr)
 	WORD value = ptr ? ptr->action : (WORD) Emulator->ActionMegaModulePage();
 
 	sprintf(msgbuffer, "%d", value);
-	if (GUI->EditBox("MEGAMODULE PAGE:", "(enter 0 to 256)", msgbuffer, 3, true) == 1) {
-		value = strtol(msgbuffer, NULL, 10);
-		if (value <= MEGA_MODULE_MAX_PAGES) {
-			Emulator->ActionMegaModulePage(true, (BYTE) value);
-			GUI->uiSetChanges |= PS_CLOSEALL;
-		}
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionMemMegaModulePageCallback);
+	GUI->EditBox("MEGAMODULE PAGE:", "(enter 0 to 256)", msgbuffer, 3, true);
 
 	return false;
 }
@@ -938,19 +913,16 @@ bool ccb_joy_keyset(GUI_MENU_ENTRY *ptr)
 bool ccb_joy_sens(GUI_MENU_ENTRY *ptr)
 {
 	TSettings::SetJoystickGPIO *gpio = Settings->Joystick->GPIO0;
-	WORD gpio_w = (ptr->action & 0x100);
 	if ((ptr->action >> 8) == GP_GPIO_1)
 		gpio = Settings->Joystick->GPIO1;
 
 	int value = gpio->sensitivity;
 
 	sprintf(msgbuffer, "%d", value);
-	if (GUI->EditBox("AXIS SENSITIVITY:", "(lower is more sensitive)", msgbuffer, 2, true) == 1) {
-		value = strtol(msgbuffer, NULL, 10);
-		if (value >= 1 && value < 100) {
-			gpio->sensitivity = value;
-		}
-	}
+	msgbuffer[0x100] = (ptr->action >> 8);
+
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionJoySensitivityCallback);
+	GUI->EditBox("AXIS SENSITIVITY:", "(lower is more sensitive)", msgbuffer, 2, true);
 
 	return false;
 }
@@ -980,18 +952,12 @@ bool ccb_joy_select(GUI_MENU_ENTRY *ptr)
 	char *input = (char *) uicch;
 	sprintf(msgbuffer, "(total controllers = %d)", devCount);
 	sprintf(input, "%d", value);
-	if (GUI->EditBox("CONTROLLER NUMBER:", msgbuffer, input, 1, true) == 1) {
-		value = strtol(input, NULL, 10);
-		if (value >= 1 && value <= devCount) {
-			const char *guid = SDL_GameControllerGetSerial(controllers[value - 1]);
-			delete gpio->guid;
-			gpio->guid = new char[strlen(guid) + 1];
-			strcpy(gpio->guid, guid);
+	input[31] = ptr->action;
 
-			Emulator->ActionJoyControllers(NULL, true);
-			ptr->detail(ptr);
-		}
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionJoySelectionCallback);
+	GUI->EditBox("CONTROLLER NUMBER:", msgbuffer, input, 1, true);
+
+	// TODO FIXME: missing `ptr->detail(ptr)`
 
 	return false;
 }
@@ -1021,21 +987,8 @@ bool ccb_blk_strt(GUI_MENU_ENTRY *ptr)
 	int value = ((ptr) ? ptr->action : Settings->MemoryBlock->start);
 
 	sprintf(msgbuffer, Settings->MemoryBlock->hex ? "#%04X" : "%d", value);
-	if (GUI->EditBox("CHANGE START ADDRESS:", NULL, msgbuffer, 5, false) == 1) {
-		if (msgbuffer[0] == '#') {
-			value = strtol(msgbuffer + 1, NULL, 16);
-			if (value == 0 && msgbuffer[1] != '0')
-				value = -1;
-		}
-		else {
-			value = strtol(msgbuffer, NULL, 10);
-			if (value == 0 && msgbuffer[0] != '0')
-				value = -1;
-		}
-
-		if (value >= 0 && value < 65536)
-			Settings->MemoryBlock->start = (WORD) value;
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionMemBlockAddressCallback);
+	GUI->EditBox("CHANGE START ADDRESS:", NULL, msgbuffer, 5, false);
 
 	return false;
 }
@@ -1045,21 +998,8 @@ bool ccb_blk_leng(GUI_MENU_ENTRY *ptr)
 	int value = ((ptr) ? ptr->action : Settings->MemoryBlock->length);
 
 	sprintf(msgbuffer, Settings->MemoryBlock->hex ? "#%04X" : "%d", value);
-	if (GUI->EditBox("CHANGE LENGTH:", NULL, msgbuffer, 5, false) == 1) {
-		if (msgbuffer[0] == '#') {
-			value = strtol(msgbuffer + 1, NULL, 16);
-			if (value == 0 && msgbuffer[1] != '0')
-				value = -1;
-		}
-		else {
-			value = strtol(msgbuffer, NULL, 10);
-			if (value == 0 && msgbuffer[0] != '0')
-				value = -1;
-		}
-
-		if (value >= 0 && value < 65536)
-			Settings->MemoryBlock->length = (WORD) value;
-	}
+	GUI->editBox->callback.connect(Emulator, &TEmulator::ActionMemBlockLengthCallback);
+	GUI->EditBox("CHANGE LENGTH:", NULL, msgbuffer, 5, false);
 
 	return false;
 }

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -1284,6 +1284,139 @@ int TEmulator::ActionJoyControllers(SDL_GameController ***controllers, bool refr
 	return joystick->GetControllers(controllers, refresh);
 }
 //---------------------------------------------------------------------------
+void TEmulator::ActionScreenBorderCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	WORD newValue = strtol(buffer, NULL, 10);
+	if (newValue == 0 && buffer[0] != '0')
+		newValue = -1;
+
+	if (newValue >= 0 && newValue <= 9) {
+		Settings->Screen->border = (BYTE) newValue;
+		GUI->uiSetChanges |= PS_SCREEN_SIZE;
+	}
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionSoundVolumeCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	WORD value = strtol(buffer, NULL, 10);
+	if (value > 1 && value <= 127) {
+		Settings->Sound->volume = (BYTE) value;
+		GUI->uiSetChanges |= PS_SOUND;
+	}
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionEmulationSpeedCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	WORD value = strtol(buffer, NULL, 10);
+	if (value == 0 && buffer[0] != '0')
+		value = 100;
+	else if (value < 10 && value > 1000)
+		value = 100;
+
+	Settings->emulationSpeed = ((double) value / 100.0f);
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionMemMegaModulePageCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	WORD value = strtol(buffer, NULL, 10);
+	if (value <= MEGA_MODULE_MAX_PAGES) {
+		ActionMegaModulePage(true, (BYTE) value);
+		GUI->uiSetChanges |= PS_CLOSEALL;
+	}
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionJoySensitivityCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	TSettings::SetJoystickGPIO *gpio = Settings->Joystick->GPIO0;
+	if (buffer[0x100] == GP_GPIO_1)
+		gpio = Settings->Joystick->GPIO1;
+
+	WORD value = strtol(buffer, NULL, 10);
+	if (value >= 1 && value < 100) {
+		gpio->sensitivity = value;
+	}
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionJoySelectionCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	TSettings::SetJoystickGPIO *gpio = Settings->Joystick->GPIO0;
+	if (buffer[31] == GP_GPIO_1)
+		gpio = Settings->Joystick->GPIO1;
+
+	SDL_GameController **controllers;
+	int devCount = Emulator->ActionJoyControllers(&controllers, false);
+
+	WORD value = strtol(buffer, NULL, 10);
+	if (value >= 1 && value <= devCount) {
+		const char *guid = SDL_GameControllerGetSerial(controllers[value - 1]);
+		delete gpio->guid;
+		gpio->guid = new char[strlen(guid) + 1];
+		strcpy(gpio->guid, guid);
+
+		Emulator->ActionJoyControllers(NULL, true);
+	}
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionMemBlockAddressCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	int value;
+	if (buffer[0] == '#') {
+		value = strtol(buffer + 1, NULL, 16);
+		if (value == 0 && buffer[1] != '0')
+			value = -1;
+	}
+	else {
+		value = strtol(buffer, NULL, 10);
+		if (value == 0 && buffer[0] != '0')
+			value = -1;
+	}
+
+	if (value >= 0 && value < 65536)
+		Settings->MemoryBlock->start = (WORD) value;
+}
+//---------------------------------------------------------------------------
+void TEmulator::ActionMemBlockLengthCallback(char *buffer, BYTE result)
+{
+	if (result != 1)
+		return;
+
+	int value;
+	if (msgbuffer[0] == '#') {
+		value = strtol(msgbuffer + 1, NULL, 16);
+		if (value == 0 && msgbuffer[1] != '0')
+			value = -1;
+	}
+	else {
+		value = strtol(msgbuffer, NULL, 10);
+		if (value == 0 && msgbuffer[0] != '0')
+			value = -1;
+	}
+
+	if (value >= 0 && value < 65536)
+		Settings->MemoryBlock->length = (WORD) value;
+}
+//---------------------------------------------------------------------------
 void TEmulator::SetComputerModel(bool fromSnap, int snapRomLen, BYTE *snapRom)
 {
 	int fileSize;

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -90,6 +90,15 @@ class TEmulator : public sigslot::has_slots<>
 		void ActionHideCursor(bool hide = false);
 		int  ActionJoyControllers(SDL_GameController ***controllers = NULL, bool refresh = false);
 
+		void ActionScreenBorderCallback(char *buffer, BYTE result);
+		void ActionSoundVolumeCallback(char *buffer, BYTE result);
+		void ActionEmulationSpeedCallback(char *buffer, BYTE result);
+		void ActionMemMegaModulePageCallback(char *buffer, BYTE result);
+		void ActionJoySensitivityCallback(char *buffer, BYTE result);
+		void ActionJoySelectionCallback(char *buffer, BYTE result);
+		void ActionMemBlockAddressCallback(char *buffer, BYTE result);
+		void ActionMemBlockLengthCallback(char *buffer, BYTE result);
+
 	private:
 		bool inmenu;
 		SDL_Event exposeEvent;


### PR DESCRIPTION
Refactor popup dialogs to use uniform event handler from main thread, and get rid of while-loops within other parts of code.
- [ ] [gui/CommonDialog.cpp > AboutDialog](https://github.com/mborik/GPMD85Emulator/blob/master/gui/CommonDialog.cpp#L22)
- [ ] [gui/CommonDialog.cpp > QueryDialog](https://github.com/mborik/GPMD85Emulator/blob/master/gui/CommonDialog.cpp#L173)
- [ ] [gui/CommonDialog.cpp > MessageBox](https://github.com/mborik/GPMD85Emulator/blob/master/gui/CommonDialog.cpp#L323)
- [ ] [gui/EditDialog.cpp > EditBox](https://github.com/mborik/GPMD85Emulator/blob/master/gui/EditDialog.cpp)

Suggested steps:
- [ ] Extend [`GUI_MENU_TYPE`](https://github.com/mborik/GPMD85Emulator/blob/master/gui/UserInterface.h#L96) with these dialog types (`_ABOUT`, `_QUERY`, `_MESSAGE_BOX`, `_EDITBOX`)
- [ ] Introduce typedef struct `GUI_EDITBOX_DATA` into [UserInterface.h](https://github.com/mborik/GPMD85Emulator/blob/master/gui/UserInterface.h#L95) with all input parameters (`title`, `description`, `buffer`, `maxLength`, `decimal`), current state variables (`x`, `y`, `w`, `len`, `cursor`, `result`, `atTheEnd`, `change`) and `sigslot::signal2<char *, BYTE> callback` (sending `buffer` and `result`)
- [ ] Separate all key-handler switches from inner event loops to appropriate methods (`KeyhandlerEditBox`, `KeyhandlerCommonDialog` for About and MessageBox, and `KeyhandlerQueryDialog`) and integrate into [`MenuHandleKey`](https://github.com/mborik/GPMD85Emulator/blob/master/gui/UserInterface.cpp#L609)
- [ ] Separate all GUI drawing code to appropriate methods (`DrawEditBox`, `DrawAboutDialog`, `DrawMessageBox`, and `DrawQueryDialog`) and integrate into [`MenuOpen` switch](https://github.com/mborik/GPMD85Emulator/blob/master/gui/UserInterface.cpp#L497)

This is a prerequisite for the proper execution of the Emscripten/WASM build, where an additional infinite loop for polling events leads to the entire application becoming hung.