### PR TITLE
Fix memory block loading and command-line parsing

### DIFF
--- a/gui/MemDumpDialog.cpp
+++ b/gui/MemDumpDialog.cpp
@@ -227,7 +227,11 @@ void UserInterface::MemDumpDialogContent(bool saveType)
 		}
 		else if (!saveType && ImGui::Button("Load", ImVec2(baseWidth, 0.0f))) {
 			ImGui::CloseCurrentPopup();
-			Emulator->ProcessRawFile(false);
+			Settings->MemoryBlock->start = mdBlockStart;
+			Settings->MemoryBlock->length = mdBlockLength;
+			Settings->MemoryBlock->autorunAddr = mdAutorunAddr;
+			if (!Emulator->ProcessRawFile(false, true))
+				debug("MemoryBlock", "GUI load failed");
 		}
 
 		ImGui::EndDisabled();

--- a/src/ArgvParser.cpp
+++ b/src/ArgvParser.cpp
@@ -22,6 +22,8 @@
 //-----------------------------------------------------------------------------
 #include "ArgvParser.h"
 #include "globals.h"
+#include <errno.h>
+#include <limits.h>
 //-----------------------------------------------------------------------------
 #define SWPAR(str) str, false, -1
 #define NOVAL INT32_MIN
@@ -127,6 +129,32 @@ void IntroMessage()
 	printf("\n- Distributed under the MIT License. See LICENSE.md for details.\n\n");
 }
 //-----------------------------------------------------------------------------
+static bool ParseIntegerArgument(const char *value, int *result)
+{
+	if (value == NULL || *value == '\0')
+		return false;
+
+	errno = 0;
+	char *end = NULL;
+	int base = 10;
+	const char *number = value;
+
+	if (strncasecmp(number, "0x", 2) == 0) {
+		base = 16;
+		number += 2;
+		if (*number == '\0')
+			return false;
+	}
+
+	long parsed = strtol(number, &end, base);
+	if (errno == ERANGE || end == number || *end != '\0' ||
+		parsed < INT_MIN || parsed > INT_MAX)
+		return false;
+
+	*result = (int) parsed;
+	return true;
+}
+//-----------------------------------------------------------------------------
 bool ParseOptions(int *argc, char *(*argv[]))
 {
 	unsigned q;
@@ -176,15 +204,10 @@ bool ParseOptions(int *argc, char *(*argv[]))
 							ret = false;
 						}
 
-						errnum = 0;
-						if (strncasecmp(args[i + 1], "0x", 2) == 0)
-							transcode = strtol(&(args[i + 1][2]), &ptr, 16);
-						else
-							transcode = strtol(args[i + 1], &ptr, 10);
-
-						if (errnum != 0) {
+						if (!ParseIntegerArgument(args[i + 1], &transcode)) {
 							warning("Arguments", "Value %s is not correct argument for parameter %s", args[i + 1], args[i]);
 							ret = false;
+							break;
 						}
 
 						*((int *) cmdline.switches[q].variable) = transcode;

--- a/src/ArgvParser.cpp
+++ b/src/ArgvParser.cpp
@@ -190,6 +190,7 @@ bool ParseOptions(int *argc, char *(*argv[]))
 								(cmdline.switches[q].par_descr == NULL ? "" : cmdline.switches[q].par_descr));
 
 							ret = false;
+							break;
 						}
 
 						*((char **) cmdline.switches[q].variable) = args[i + 1];
@@ -202,6 +203,7 @@ bool ParseOptions(int *argc, char *(*argv[]))
 								(cmdline.switches[q].par_descr == NULL ? "" : cmdline.switches[q].par_descr));
 
 							ret = false;
+							break;
 						}
 
 						if (!ParseIntegerArgument(args[i + 1], &transcode)) {

--- a/src/ArgvParser.cpp
+++ b/src/ArgvParser.cpp
@@ -114,7 +114,10 @@ TCmdLineSwitch switches[] = {
 	{ "-ptr", "--memblock-address", VAR_INT, (void *) &argv_config.memstart,
 				"load memory block at given address", SWPAR("{WORD}") },
 };
-TCmdLineSwitches cmdline = { switches, 27 };
+TCmdLineSwitches cmdline = {
+	switches,
+	(unsigned) (sizeof(switches) / sizeof(switches[0]))
+};
 //-----------------------------------------------------------------------------
 void IntroMessage()
 {

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -2165,7 +2165,7 @@ void TEmulator::SelectRawFile(const char *fileName, bool save)
 	}
 }
 //---------------------------------------------------------------------------
-bool TEmulator::ProcessRawFile(bool save)
+bool TEmulator::ProcessRawFile(bool save, bool allowAutorun)
 {
 	int length = Settings->MemoryBlock->length,
 	     start = Settings->MemoryBlock->start;
@@ -2261,6 +2261,15 @@ bool TEmulator::ProcessRawFile(bool save)
 		debug("MemoryBlock", "Mapping restored: reset=%d allRAM=%d remapped=%d page=%d",
 			memory->IsInReset(), memory->IsAllRAM(), memory->IsRemapped(),
 			memory->IsMem256() ? memory->GetPage() : -1);
+
+		// Apply GUI Autorun only after a successful load and mapping restore.
+		if (!save && allowAutorun && Settings->MemoryBlock->autorun) {
+			WORD oldPC = cpu->GetPC();
+			WORD autorunAddr = (WORD) Settings->MemoryBlock->autorunAddr;
+			debug("MemoryBlock", "Autorun requested: address=#%04X", autorunAddr);
+			cpu->SetPC(autorunAddr);
+			debug("MemoryBlock", "PC changed: #%04X -> #%04X", oldPC, autorunAddr);
+		}
 
 		if (save) {
 			int bytesWritten = WriteToFile(fn, 0, length, buff, true);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -2181,19 +2181,30 @@ bool TEmulator::ProcessRawFile(bool save)
 	if (!fn)
 		return false;
 
+	debug("MemoryBlock", "%s path='%s' start=#%04X length=%d",
+		save ? "Saving" : "Loading", fn, start, length);
+
 	ActionPlayPause(false, false);
 
-	BYTE *buff = NULL;
+	BYTE *buff = new BYTE[length];
 	bool ret = true;
 	bool oldState = false;
 	bool oldAllRAM = false;
 	int oldPage = -1;
 
-	if (!save)
-		length = ReadFromFile(fn, 0, length, buff);
+	if (!save) {
+		int bytesRead = ReadFromFile(fn, 0, length, buff);
+		debug("MemoryBlock", "Read result: %d/%d bytes", bytesRead, length);
+		if (bytesRead != length) {
+			debug("MemoryBlock", "Load failed before memory write");
+			ret = false;
+		}
+	}
 
-	if (length > 0) {
-		buff = new BYTE[length];
+	if (ret) {
+		debug("MemoryBlock", "Mapping before: reset=%d allRAM=%d remapped=%d page=%d",
+			memory->IsInReset(), memory->IsAllRAM(), memory->IsRemapped(),
+			memory->IsMem256() ? memory->GetPage() : -1);
 
 		if (memory->HasAllRAM()) {
 			oldAllRAM = memory->IsAllRAM();
@@ -2212,6 +2223,9 @@ bool TEmulator::ProcessRawFile(bool save)
 			oldPage = memory->GetPage();
 			memory->SetPage((BYTE) Settings->MemoryBlock->ex256pg);
 		}
+		debug("MemoryBlock", "Mapping for operation: reset=%d allRAM=%d remapped=%d page=%d",
+			memory->IsInReset(), memory->IsAllRAM(), memory->IsRemapped(),
+			memory->IsMem256() ? memory->GetPage() : -1);
 
 		if (save) {
 			for (int i = 0; i < length; i++)
@@ -2231,14 +2245,15 @@ bool TEmulator::ProcessRawFile(bool save)
 		if (memory->IsMem256())
 			memory->SetPage((BYTE) oldPage);
 
-		if (save && WriteToFile(fn, 0, length, buff, true) < 0)
-			ret = false;
+		if (save) {
+			int bytesWritten = WriteToFile(fn, 0, length, buff, true);
+			debug("MemoryBlock", "Write result: %d/%d bytes", bytesWritten, length);
+			if (bytesWritten != length)
+				ret = false;
+		}
 	}
-	else
-		ret = false;
 
-	if (buff)
-		delete [] buff;
+	delete [] buff;
 	delete [] fn;
 
 	ActionPlayPause(!Settings->isPaused, false);

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -2176,13 +2176,27 @@ bool TEmulator::ProcessRawFile(bool save)
 		return false;
 	if ((start + length) > 65535)
 		length = 65536 - start;
+	int requestedLength = length;
 
 	char *fn = ComposeFilePath(Settings->MemoryBlock->fileName);
 	if (!fn)
 		return false;
 
-	debug("MemoryBlock", "%s path='%s' start=#%04X length=%d",
-		save ? "Saving" : "Loading", fn, start, length);
+	debug("MemoryBlock", "%s path='%s' start=#%04X requested length=%d",
+		save ? "Saving" : "Loading", fn, start, requestedLength);
+
+	if (!save) {
+		long fileLength = FileSize(fn);
+		if (fileLength <= 0) {
+			debug("MemoryBlock", "Load failed: invalid file size=%ld", fileLength);
+			delete [] fn;
+			return false;
+		}
+		if (fileLength < length)
+			length = (int) fileLength;
+		debug("MemoryBlock", "File size=%ld, effective length=%d",
+			fileLength, length);
+	}
 
 	ActionPlayPause(false, false);
 

--- a/src/Emulator.cpp
+++ b/src/Emulator.cpp
@@ -2258,6 +2258,9 @@ bool TEmulator::ProcessRawFile(bool save)
 			memory->ResetOn();
 		if (memory->IsMem256())
 			memory->SetPage((BYTE) oldPage);
+		debug("MemoryBlock", "Mapping restored: reset=%d allRAM=%d remapped=%d page=%d",
+			memory->IsInReset(), memory->IsAllRAM(), memory->IsRemapped(),
+			memory->IsMem256() ? memory->GetPage() : -1);
 
 		if (save) {
 			int bytesWritten = WriteToFile(fn, 0, length, buff, true);

--- a/src/Emulator.h
+++ b/src/Emulator.h
@@ -65,7 +65,7 @@ class TEmulator
 
 		void ProcessArgvOptions(bool memModifiers = false);
 		void ProcessSettings(BYTE filter);
-		bool ProcessRawFile(bool save);
+		bool ProcessRawFile(bool save, bool allowAutorun = false);
 
 		void BaseTimerCallback(bool guiWantCapture = false);
 		void CpuTimerCallback();

--- a/src/SystemPIO.cpp
+++ b/src/SystemPIO.cpp
@@ -524,6 +524,9 @@ void SystemPIO::ReadKeyboardC()
 void SystemPIO::WritePaging()
 {
 	BYTE pg = PeripheralReadByte(PP_PortC);
+	bool oldReset = memory->IsInReset();
+	bool oldAllRAM = memory->IsAllRAM();
+	bool oldRemapped = memory->IsRemapped();
 
 	if (model == CM_C2717) {
 		width384 = ((pg & 32) + 1);       // 48/64 chars per line mode
@@ -539,6 +542,13 @@ void SystemPIO::WritePaging()
 			else
 				memory->SetAllRAM(true);  // AllRAM
 		}
+	}
+	if (oldReset != memory->IsInReset() ||
+		oldAllRAM != memory->IsAllRAM() ||
+		oldRemapped != memory->IsRemapped()) {
+		debug("SystemPIO", "Memory paging: portC=#%02X reset=%d->%d allRAM=%d->%d remapped=%d->%d",
+			pg, oldReset, memory->IsInReset(), oldAllRAM, memory->IsAllRAM(),
+			oldRemapped, memory->IsRemapped());
 	}
 
 	// AllRAM


### PR DESCRIPTION
# Fix memory block loading and command-line parsing

## Memory block loading

`Load to Memory` read the file before allocating its buffer. The read target
was a null pointer, so the loaded bytes were not available for writing to
emulated memory.

This PR allocates the buffer before reading the file.

It also:

- uses the actual file size when the selected block length is longer than the file;
- checks file read and write results;
- adds debug logs for file operations and temporary memory mapping changes;
- applies Start, Length, and Autorun address from the GUI load dialog; and
- sets the program counter after a successful GUI load when Autorun is enabled.

fixes #38 

## Command-line parsing

The command-line option table has 26 entries, but its count was set to 27.
`--help` therefore read one entry past the end of the table and could crash.

This PR calculates the count from the table itself. It also rejects invalid
integer values and stops processing an option when its required value is
missing.

fixes #39 

---

Therefore, I can now use this app to debug my PMD program (a slideshow app).😃
Feedback is welcome.

---

P.S.
I previously traveled to the Czech Republic and Slovakia. I remember the beautiful cityscapes and scenery in both places.
Last year, when Maker Faire Tokyo was held in Japan, the PMD85 was on display. As memories of my travels came flooding back, I became interested in this computer and listened to the explanation.
Maker Faire Tokyo 2025 report
https://akiba-pc.watch.impress.co.jp/docs/news/news/2053370.html

Afterward, I tried developing software that runs on the PMD85, using C and assembly language. Development was difficult due to a lack of information, but your website was extremely helpful.
The Windows emulator was helpful for development verification. I'm also looking forward to the improvements in the Linux version.

<img width="450" height="" alt="my app" src="https://github.com/user-attachments/assets/501222a1-0511-425f-8269-c45e8ef92623" />
